### PR TITLE
Start slapd, but only for ldapi: service so that no TCP ports are open.

### DIFF
--- a/openldap/2.5/debian-11/Dockerfile
+++ b/openldap/2.5/debian-11/Dockerfile
@@ -7,14 +7,14 @@
 FROM ${ARCH}docker.io/bitnami/minideb:bullseye
 
 ARG TARGETARCH
-ARG NOW
+ARG NOW BUILD
 
 LABEL \
       org.opencontainers.image.base.name="docker.io/bitnami/minideb:bullseye" \
       org.opencontainers.image.created="${NOW}" \
       org.opencontainers.image.description="Application packaged by Symas Corp." \
       org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.ref.name="2.5.16-debian-11-r57" \
+      org.opencontainers.image.ref.name="2.5.16-debian-11-r${BUILD}" \
       org.opencontainers.image.title="openldap" \
       org.opencontainers.image.vendor="Symas Corp." \
       org.opencontainers.image.version="2.5.16"
@@ -28,7 +28,6 @@ ENV HOME="/" \
 ARG DEBIAN=11 CODENAME=bullseye
 
 COPY prebuildfs /
-# SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install required system packages and dependencies
 

--- a/openldap/2.6/debian-11/Dockerfile
+++ b/openldap/2.6/debian-11/Dockerfile
@@ -7,14 +7,14 @@
 FROM ${ARCH}docker.io/bitnami/minideb:bullseye
 
 ARG TARGETARCH
-ARG NOW
+ARG NOW BUILD
 
 LABEL \
       org.opencontainers.image.base.name="docker.io/bitnami/minideb:bullseye" \
       org.opencontainers.image.created="${NOW}" \
       org.opencontainers.image.description="Application packaged by Symas Corp." \
       org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.ref.name="2.6.6-debian-11-r57" \
+      org.opencontainers.image.ref.name="2.6.6-debian-11-r${BUILD}" \
       org.opencontainers.image.title="openldap" \
       org.opencontainers.image.vendor="Symas Corp." \
       org.opencontainers.image.version="2.6.6"
@@ -28,7 +28,6 @@ ENV HOME="/" \
 ARG DEBIAN=11 CODENAME=bullseye
 
 COPY prebuildfs /
-# SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install required system packages and dependencies
 

--- a/openldap/2.6/debian-11/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/openldap/2.6/debian-11/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -257,7 +257,7 @@ is_ldap_not_running() {
 ldap_start_bg() {
     local -r retries="${1:-12}"
     local -r sleep_time="${2:-1}"
-    local -a flags=("-h" "ldap://:${LDAP_PORT_NUMBER}/ ${LDAP_LDAPI_URI} " "-F" "${LDAP_CONF_DIR}/slapd.d" "-d" "$LDAP_LOGLEVEL")
+    local -a flags=("-h" "${LDAP_LDAPI_URI} " "-F" "${LDAP_CONF_DIR}/slapd.d" "-d" "$LDAP_LOGLEVEL")
 
     if is_ldap_not_running; then
         info "Starting OpenLDAP server in background"
@@ -418,12 +418,7 @@ ldap_create_online_configuration() {
         replace_in_file "${LDAP_SHARE_DIR}/slapd.ldif" "gidNumber=0" "gidNumber=$(id -g)"
     fi
     ensure_dir_exists "${LDAP_BACKEND_DATA_DIR}" ${LDAP_DAEMON_USER} ${LDAP_DAEMON_GROUP}
-    local -a flags=(-F "${LDAP_ONLINE_CONF_DIR}" -n 0 -l "${LDAP_SHARE_DIR}/slapd.ldif")
-    if am_i_root; then
-        debug_execute run_as_user "${LDAP_DAEMON_USER}" slapadd "${slapd_debug_args[@]}" "${flags[@]}"
-    else
-        debug_execute slapadd "${slapd_debug_args[@]}" "${flags[@]}"
-    fi
+    slapadd_ldif "${LDAP_SHARE_DIR}/slapd.ldif"
 }
 
 ########################
@@ -472,7 +467,7 @@ add: olcRootPW
 olcRootPW: $LDAP_ENCRYPTED_CONFIG_ADMIN_PASSWORD
 EOF
     fi
-    debug_execute ldapmodify "${slapd_debug_args[@]}" -Y EXTERNAL -H "$LDAP_LDAPI_URI" -f "${LDAP_SHARE_DIR}/admin.ldif"
+    ldapmodify_ldif "${LDAP_SHARE_DIR}/admin.ldif" -Y EXTERNAL
 }
 
 ########################
@@ -497,7 +492,7 @@ changetype: modify
 add: olcRequires
 olcRequires: authc
 EOF
-    debug_execute ldapmodify "${slapd_debug_args[@]}" -Y EXTERNAL -H "$LDAP_LDAPI_URI" -f "${LDAP_SHARE_DIR}/disable_anon_bind.ldif"
+    ldapmodify_ldif "${LDAP_SHARE_DIR}/disable_anon_bind.ldif" -Y EXTERNAL
 }
 
 ########################
@@ -517,7 +512,7 @@ ldap_add_schemas() {
         if [ ! -f "${LDAP_CONF_DIR}/schema/${schema}.ldif" ]; then
             error "Extra schema ${schema} does not exist at ${LDAP_CONF_DIR}/schema/${schema}.ldif"
         fi
-	slapadd_ldif "${schema}.ldif" "${LDAP_CONF_DIR}/schema}"
+        ldapadd_ldif "${LDAP_CONF_DIR}/schema/${schema}.ldif" -Y EXTERNAL
     done
 }
 
@@ -533,6 +528,7 @@ ldap_add_schemas() {
 ldap_add_custom_schema() {
     info "Adding custom Schema from ${LDAP_CUSTOM_SCHEMA_FILE} ..."
     slapadd_ldif "${LDAP_CUSTOM_SCHEMA_FILE}"
+#    ldap_stop; while is_ldap_running; do sleep 1; done; ldap_start_bg
 }
 
 ########################
@@ -548,8 +544,9 @@ ldap_add_custom_schemas() {
     info "Adding custom schemas in ${LDAP_CUSTOM_SCHEMA_DIR} ..."
     for schema in $(find "$LDAP_CUSTOM_SCHEMA_DIR" -maxdepth 1 \( -type f -o -type l \) -iname '*.ldif' -print | sort); do
         info "\t${schema}"
-	slapadd_ldif "${schema}"
+        slapadd_ldif "${schema}"
     done
+#    ldap_stop; while is_ldap_running; do sleep 1; done; ldap_start_bg
 }
 
 ########################
@@ -625,7 +622,7 @@ member: ${user/#/cn=},${LDAP_USER_DC/#/ou=},${LDAP_ROOT}
 EOF
     done
 
-    slapadd_ldif "tree.ldif" "${LDAP_SHARE_DIR}"
+    ldapadd_ldif "${LDAP_SHARE_DIR}/tree.ldif" -D "${LDAP_ADMIN_DN}" -w "${LDAP_ADMIN_PASSWORD}"
 }
 
 ########################
@@ -642,7 +639,7 @@ ldap_add_custom_ldifs() {
     info "Loading custom LDIF files..."
     for ldif in $(find "${LDAP_CUSTOM_LDIF_DIR}" -maxdepth 1 \( -type f -o -type l \) -iname '*.ldif' -print | sort); do
         info "\t${ldif}"
-	slapadd_ldif "${ldif}"
+        ldapadd_ldif "${ldif}" -D "${LDAP_ADMIN_DN}" -w "${LDAP_ADMIN_PASSWORD}"
     done
 }
 
@@ -701,6 +698,7 @@ ldap_initialize() {
 
         # Create OpenLDAP online configuration
         ldap_create_online_configuration
+        ldap_start_bg
         ldap_admin_credentials
         info "Setting up optional config..."
         if ! is_boolean_yes "$LDAP_ALLOW_ANON_BINDING"; then
@@ -749,7 +747,7 @@ ldap_initialize() {
             info "Skipping default schemas/tree structure"
         fi
         info "OpenLDAP configuration and databases are now configured for service."
-        ldap_stop
+        ldap_stop; while is_ldap_running; do sleep 1; done
     else
         info "Preserving existing config and data in ${LDAP_VOLUME_DIR}/{data,slapd.d}"
     fi
@@ -766,35 +764,35 @@ ldap_initialize() {
 #########################
 ldap_custom_init_scripts() {
     if [[ -f "${LDAP_VOLUME_DIR}/.user_scripts_initialized" ]]; then
-	debug "\tskipping because ${LDAP_VOLUME_DIR}/.user_scripts_initialized exists"
+        debug "\tskipping because ${LDAP_VOLUME_DIR}/.user_scripts_initialized exists"
         return 0
     fi
     if is_dir_empty "${LDAP_ENTRYPOINT_INITDB_D_DIR}"; then
-	debug "\tnone found"
+        debug "\tnone found"
         return 0
     fi
     read -r -a config_files <<< "$(find "${LDAP_ENTRYPOINT_INITDB_D_DIR}"/ -maxdepth 1 -type f -print0 | xargs -0)"
     for f in "${config_files[@]}"; do
-	ret_code=-1
+        ret_code=-1
         case "$f" in
             *.ldif)
-		info "\tslapadd $f"
-		slapadd_ldif "$f"
-		ret_code=$?
+                info "\tslapadd $f"
+                slapadd_ldif "$f"
+                ret_code=$?
                 if [[ $ret_code -ne 0 ]]; then
                     error "failed loading $f ($ret_code)"
                     return 1
                 fi
-		;;
+                ;;
             *.sh)
                 if [[ -x "$f" ]]; then
                     info "\texecuting $f"
                     if is_boolean_yes "${SYMAS_DEBUG_SETUP:-}"; then
                         bash -x "$f"
-			ret_code=$?
+                        ret_code=$?
                     else
                         bash "$f"
-			ret_code=$?
+                        ret_code=$?
                     fi
                     if [[ $ret_code -ne 0 ]]; then
                         error "failed executing $f ($ret_code)"
@@ -808,16 +806,16 @@ ldap_custom_init_scripts() {
                 fi
                 ;;
             *)
-		if [[ -x "$f" ]]; then
-		    info "\texecuting $f"
-		    exec "$f"
-		    ret_code=$?
-		    if [[ $ret_code -ne 0 ]]; then
+                if [[ -x "$f" ]]; then
+                    info "\texecuting $f"
+                    exec "$f"
+                    ret_code=$?
+                    if [[ $ret_code -ne 0 ]]; then
                         error "failed executing $f ($ret_code)"
                         return 1
-		    fi
+                    fi
                 else
-		    warn "\tskipping $f, not executable or Bash shell (.sh) script"
+                    warn "\tskipping $f, not executable or Bash shell (.sh) script"
                 fi
                 ;;
         esac
@@ -858,7 +856,7 @@ replace: olcTLSDHParamFile
 olcTLSDHParamFile: $LDAP_TLS_DH_PARAMS_FILE
 EOF
     fi
-    debug_execute ldapmodify "${slapd_debug_args[@]}" -Y EXTERNAL -H "$LDAP_LDAPI_URI" -f "${LDAP_SHARE_DIR}/certs.ldif"
+    ldapmodify_ldif "${LDAP_SHARE_DIR}/certs.ldif" -Y EXTERNAL
 }
 
 ########################
@@ -878,7 +876,7 @@ changetype: modify
 add: olcSecurity
 olcSecurity: tls=1
 EOF
-    debug_execute ldapmodify "${slapd_debug_args[@]}" -Y EXTERNAL -H "$LDAP_LDAPI_URI" -f "${LDAP_SHARE_DIR}/tls_required.ldif"
+    ldapmodify_ldif "${LDAP_SHARE_DIR}/tls_required.ldif" -Y EXTERNAL
 }
 
 ########################
@@ -900,7 +898,12 @@ objectClass: olcModuleList
 olcModulePath: $1
 olcModuleLoad: $2
 EOF
-    slapadd_ldif "${LDAP_SHARE_DIR}/enable_module_${2}.ldif" "${LDAP_ONLINE_CONF_DIR}"
+
+    if is_ldap_running; then
+        ldapadd_ldif "${LDAP_SHARE_DIR}/enable_module_${2}.ldif" -Y EXTERNAL
+    else
+        slapadd_ldif "${LDAP_SHARE_DIR}/enable_module_${2}.ldif" "${LDAP_ONLINE_CONF_DIR}" -Y EXTERNAL
+    fi
 }
 
 ########################
@@ -922,7 +925,7 @@ objectClass: olcOverlayConfig
 objectClass: olcPPolicyConfig
 olcOverlay: {0}ppolicy
 EOF
-    slapadd_ldif "${LDAP_SHARE_DIR}/ppolicy_create_configuration.ldif"
+    ldapadd_ldif "${LDAP_SHARE_DIR}/ppolicy_create_configuration.ldif" -Q -Y EXTERNAL
     # enable ppolicy_hash_cleartext
     if is_boolean_yes "$LDAP_PPOLICY_HASH_CLEARTEXT"; then
         info "Enabling ppolicy_hash_cleartext"
@@ -932,7 +935,7 @@ changetype: modify
 add: olcPPolicyHashCleartext
 olcPPolicyHashCleartext: TRUE
 EOF
-    debug_execute ldapmodify "${slapd_debug_args[@]}" -Q -Y EXTERNAL -H "$LDAP_LDAPI_URI" -f "${LDAP_SHARE_DIR}/ppolicy_configuration_hash_cleartext.ldif"
+    ldapmodify_ldif "${LDAP_SHARE_DIR}/ppolicy_configuration_hash_cleartext.ldif" -Q -Y EXTERNAL
     fi
     # enable ppolicy_use_lockout
     if is_boolean_yes "$LDAP_PPOLICY_USE_LOCKOUT"; then
@@ -943,7 +946,7 @@ changetype: modify
 add: olcPPolicyUseLockout
 olcPPolicyUseLockout: TRUE
 EOF
-        debug_execute ldapmodify "${slapd_debug_args[@]}" -Q -Y EXTERNAL -H "$LDAP_LDAPI_URI" -f "${LDAP_SHARE_DIR}/ppolicy_configuration_use_lockout.ldif"
+        ldapmodify_ldif "${LDAP_SHARE_DIR}/ppolicy_configuration_use_lockout.ldif" -Q -Y EXTERNAL
     fi
 }
 
@@ -966,31 +969,31 @@ changetype: modify
 add: olcPasswordHash
 EOF
     case "${LDAP_PASSWORD_HASH}" in
-	"{ARGON2}")
-	    ldap_load_module "${LDAP_BASE_DIR}/lib/openldap" "argon2.so"
-	    cat >> "${LDAP_SHARE_DIR}/password_hash.ldif" << EOF
+        "{ARGON2}")
+            ldap_load_module "${LDAP_BASE_DIR}/lib/openldap" "argon2.so"
+            cat >> "${LDAP_SHARE_DIR}/password_hash.ldif" << EOF
 olcPasswordHash: ${LDAP_PASSWORD_HASH}
 EOF
-	    ;;
-	"{CRYPT}")
-	    cat >> "${LDAP_SHARE_DIR}/password_hash.ldif" << EOF
+            ;;
+        "{CRYPT}")
+            cat >> "${LDAP_SHARE_DIR}/password_hash.ldif" << EOF
 olcPasswordHash: ${LDAP_PASSWORD_HASH}
 olcPasswordCryptSaltFormat: ${LDAP_CRYPT_SALT_FORMAT:-$y$.16s}
 EOF
-	    ;;
-	"{SHA256}"|"{SHA384}"|"{SHA512}"|"{SSHA256}"|"{SSHA384}"|"{SSHA512}")
-	    ldap_load_module "${LDAP_BASE_DIR}/lib/openldap" "pw-sha2.so"
-	    cat >> "${LDAP_SHARE_DIR}/password_hash.ldif" << EOF
+            ;;
+        "{SHA256}"|"{SHA384}"|"{SHA512}"|"{SSHA256}"|"{SSHA384}"|"{SSHA512}")
+            ldap_load_module "${LDAP_BASE_DIR}/lib/openldap" "pw-sha2.so"
+            cat >> "${LDAP_SHARE_DIR}/password_hash.ldif" << EOF
 olcPasswordHash: ${LDAP_PASSWORD_HASH}
 EOF
-	    ;;
-	*)
-	    cat >> "${LDAP_SHARE_DIR}/password_hash.ldif" << EOF
+            ;;
+        *)
+            cat >> "${LDAP_SHARE_DIR}/password_hash.ldif" << EOF
 olcPasswordHash: ${LDAP_PASSWORD_HASH}
 EOF
-	    ;;
+            ;;
     esac
-    debug_execute ldapmodify "${slapd_debug_args[@]}" -Y EXTERNAL -H "$LDAP_LDAPI_URI" -f "${LDAP_SHARE_DIR}/password_hash.ldif"
+    ldapmodify_ldif "${LDAP_SHARE_DIR}/password_hash.ldif" -Y EXTERNAL
 }
 
 ########################
@@ -1004,8 +1007,8 @@ EOF
 #########################
 ldap_index_accesslog() {
     if ! [[ -f "${LDAP_SHARE_DIR}/accesslog_add_indexes.ldif" ]]; then
-	info "Configure Access Log Indexes"
-	cat > "${LDAP_SHARE_DIR}/accesslog_add_indexes.ldif" << EOF
+        info "Configure Access Log Indexes"
+        cat > "${LDAP_SHARE_DIR}/accesslog_add_indexes.ldif" << EOF
 dn: olcDatabase={2}mdb,cn=config
 changetype: modify
 add: olcDbIndex
@@ -1014,7 +1017,7 @@ olcDbIndex: entryCSN eq
 add: olcDbIndex
 olcDbIndex: entryUUID eq
 EOF
-	debug_execute ldapmodify "${slapd_debug_args[@]}" -Y EXTERNAL -H "$LDAP_LDAPI_URI" -f "${LDAP_SHARE_DIR}/accesslog_add_indexes.ldif"
+        ldapmodify_ldif "${LDAP_SHARE_DIR}/accesslog_add_indexes.ldif" -Y EXTERNAL
     fi
 }
 
@@ -1046,7 +1049,8 @@ olcDbIndex: default eq
 olcDbIndex: entryCSN,objectClass,reqEnd,reqResult,reqStart
 EOF
     mkdir "${LDAP_ACCESSLOG_DATA_DIR}"
-    slapadd_ldif "${LDAP_SHARE_DIR}/accesslog_create_accesslog_database.ldif"
+    ldapadd_ldif "${LDAP_SHARE_DIR}/accesslog_create_accesslog_database.ldif" -Q -Y EXTERNAL
+
     # Add AccessLog overlay
     cat > "${LDAP_SHARE_DIR}/accesslog_create_overlay_configuration.ldif" << EOF
 dn: olcOverlay=accesslog,olcDatabase={2}mdb,cn=config
@@ -1061,7 +1065,7 @@ olcAccessLogOld: $LDAP_ACCESSLOG_LOGOLD
 olcAccessLogOldAttr: $LDAP_ACCESSLOG_LOGOLDATTR
 EOF
     info "adding accesslog_create_overlay_configuration.ldif"
-    slapadd_ldif "${LDAP_SHARE_DIR}/accesslog_create_overlay_configuration.ldif"
+    ldapadd_ldif "${LDAP_SHARE_DIR}/accesslog_create_overlay_configuration.ldif" -Q -Y EXTERNAL
 }
 
 ########################
@@ -1095,7 +1099,7 @@ EOF
 olcSpSessionLog: $LDAP_SYNCPROV_SESSIONLOG
 EOF
 fi
-    slapadd_ldif "${LDAP_SHARE_DIR}/syncprov_create_overlay_configuration.ldif"
+    ldapadd_ldif "${LDAP_SHARE_DIR}/syncprov_create_overlay_configuration.ldif" -Q -Y EXTERNAL
 }
 
 ########################
@@ -1103,17 +1107,48 @@ fi
 # Globals:
 #   LDAP_*
 # Arguments:
-#   The full path to an LDIF file to load into config database 0
+#   The full path to an LDIF file to load
+#   The config dir, defaults to LDAP_ONLINE_CONF_DIR
 # Returns:
 #   None
 #########################
 slapadd_ldif() {
-    local -a flags=(-F "${2:-${LDAP_ONLINE_CONF_DIR}}" -n 0 -l "$1")
+    local argv=( "$@" )
+    argv=( "${argv[@]:2:$#}" )
+    local -a flags=(-F "${2:-${LDAP_ONLINE_CONF_DIR}}" -n 0 -l "$1") # -b "${3:-cn=config}"
     if am_i_root; then
-        debug_execute run_as_user "${LDAP_DAEMON_USER}" slapadd "${slapd_debug_args[@]}" "${flags[@]}"
+        debug_execute run_as_user "${LDAP_DAEMON_USER}" slapadd "${slapd_debug_args[@]}" "${flags[@]}" ${argv[@]}
     else
         debug_execute slapadd "${slapd_debug_args[@]}" "${flags[@]}"
     fi
+}
+
+########################
+# Execute ldapadd with predictable arguments
+# Globals:
+#   LDAP_*
+# Arguments:
+#   The full path to an LDIF file to load
+# Returns:
+#   None
+#########################
+ldapadd_ldif() {
+    local -a flags=("${slapd_debug_args[@]}" -H "$LDAP_LDAPI_URI")
+    debug_execute ldapadd  "${flags[@]}" -f ${@}
+}
+
+########################
+# Execute ldapmodify with predictable arguments
+# Globals:
+#   LDAP_*
+# Arguments:
+#   The full path to an LDIF file to load
+# Returns:
+#   None
+#########################
+ldapmodify_ldif() {
+    local -a flags=("${slapd_debug_args[@]}" -H "$LDAP_LDAPI_URI")
+    debug_execute ldapmodify  "${flags[@]}" -f ${@}
 }
 
 ########################

--- a/openldap/deploy.sh
+++ b/openldap/deploy.sh
@@ -5,12 +5,12 @@ set -euo pipefail
 set -x
 
 cd 2.5/debian-11
-n=2
+n=3
 
-docker buildx build --push --build-arg NOW="$(date --utc +%FT%TZ)" --progress=plain --no-cache --rm --platform linux/amd64 symas/openldap:2.5 -t symas/openldap:2.5.16 -t symas/openldap:2.5.16-debian-11 -t "symas/openldap:2.5.16-debian-11-r${n}" .
+docker buildx build --push --build-arg BUILD=$n --build-arg NOW="$(date --utc +%FT%TZ)" --progress=plain --no-cache --rm --platform linux/amd64 symas/openldap:2.5 -t symas/openldap:2.5.16 -t symas/openldap:2.5.16-debian-11 -t "symas/openldap:2.5.16-debian-11-r${n}" .
 
 cd ../..
 cd 2.6/debian-11
-n=9
+n=10
 
-docker buildx build --push --build-arg NOW="$(date --utc +%FT%TZ)" --progress=plain --no-cache --rm --platform linux/amd64,linux/arm64/v8 -t symas/openldap:latest -t symas/openldap:2 -t symas/openldap:2.6 -t symas/openldap:2.6.6 -t symas/openldap:2.6.6-debian-11 -t "symas/openldap:2.6.6-debian-11-r${n}" .
+docker buildx build --push --build-arg BUILD=$n --build-arg NOW="$(date --utc +%FT%TZ)" --progress=plain --no-cache --rm --platform linux/amd64,linux/arm64/v8 -t symas/openldap:latest -t symas/openldap:2 -t symas/openldap:2.6 -t symas/openldap:2.6.6 -t symas/openldap:2.6.6-debian-11 -t "symas/openldap:2.6.6-debian-11-r${n}" .


### PR DESCRIPTION
### Description of the change

The problem is that Kubernetes has simple-minded default probes, when they see that they can talk to a TCP port (`SYN`, `SYN/ACK`), the service is up.  This wouldn't be an issue were it not for the fact that our setup scripts start `slapd` during config, then stop it, then start it, etc. until things are configured.  Arguably they shouldn't do that at all, they should create the config, consume it, then start the server.  But, while that might be the end goal for now we need a way to keep Kubernetes happy and not spend months re-writing this (mostly) working Bash code.  So, the short term solution is to simply not open the `ldap:` or `ldaps:` TCP interfaces when running `slapd` during configuration

We'll use a few helper functions `ldapadd/ldapmodify/slapadd_ldif()` in place of all the calls to `ldapadd/slapaddldapmodify`.

### Benefits

Won't confuse Kubernetes.